### PR TITLE
amend subroutine named inner to inner_tmpl

### DIFF
--- a/t/basic.t
+++ b/t/basic.t
@@ -13,20 +13,20 @@ use Template::Caribou::Tags qw/ render_tag /;
 
 with 'Template::Caribou';
 
-template inner => sub {
+template inner_tmpl => sub {
     'hello world';
 };
 
 template outer => sub {
     print 'x';
-    show( 'inner' );
+    show( 'inner_tmpl' );
     print 'x';
 };
 
-test 'inner' => sub {
+test 'inner_tmpl' => sub {
     my $self = shift;
 
-    is $self->render('inner') => 'hello world';
+    is $self->render('inner_tmpl') => 'hello world';
 };
 
 test 'outer' => sub {
@@ -60,7 +60,7 @@ test 'escaping' => sub {
 
 template 'end_show' => sub {
     foo { };
-    show( 'inner' );
+    show( 'inner_tmpl' );
 };
 
 test 'end_show' => sub {


### PR DESCRIPTION
This fixes failing test with error:

t/basic.t there's already a subroutine named inner in main
at Moose/Exporter.pm line 398.

Hopefully this should resolve the cpan testers failures.