### PR TITLE
use XML::Writer when creating tags to escape quotes

### DIFF
--- a/t/tag-attributes.t
+++ b/t/tag-attributes.t
@@ -8,8 +8,6 @@ use Template::Caribou::Tags qw/ render_tag attr /;
 local *::RAW;
 open ::RAW, '>', \my $raw;
 
-local $TODO = "attribute quotes aren't dealt with smartly";
-
 unlike  render_tag( 'div', sub { attr stuff => '"'  } ) => qr/"""/,
     'attribute with double quote';
 like  render_tag( 'div', sub { attr stuff => "'"  } ) => qr/"'"/,


### PR DESCRIPTION
Refs #9 

As per our emails re the PR Pull request challenge. Not sure if this is what you were exactly after though.